### PR TITLE
fix handling task with id >= 10 issue

### DIFF
--- a/scripts/bin/fks-moveToFykos.sh
+++ b/scripts/bin/fks-moveToFykos.sh
@@ -50,12 +50,12 @@ file=`sed "s/[JNPES]-\([a-z_]*\)/\1/g" <<< $3`
 file="?-R*S*-*-$file.tex"
 file=`cd problems;ls $file`
 # this form of regex is needed because [a-z] set depends on locale
-if [[ ! ( $file =~ ^[abcdefghijklmnopqrstuvwxyz_]+$ ) ]]; then
+if [[ ! ( $file =~ ^[JNPES]-R[0123456789]+S[0123456789]-[0123456789]+-[abcdefghijklmnopqrstuvwxyz_]+\.tex$ ) ]]; then
     echo "Bad file format:" $file"."
     exit -1 
 fi
 
-prefix=`sed 's/\([JNPES]-R[0-9]*S[0-9]-[0-9]\+-\).*/\1/' <<< $file`
+prefix=`sed 's/\([JNPES]-R[0-9]\+S[0-9]-[0-9]\+-\).*/\1/' <<< $file`
 #echo -e $prefix"\n"
 
 

--- a/scripts/bin/fks-moveToFykos.sh
+++ b/scripts/bin/fks-moveToFykos.sh
@@ -6,6 +6,7 @@
 # @3 problem name
 
 source /etc/fks/config
+LC_ALL=C
 
 ulohy=$templRepoPath
 branch="problem"$1"-"$2"-branch"
@@ -50,7 +51,7 @@ file=`sed "s/[JNPES]-\([a-z_]*\)/\1/g" <<< $3`
 file="?-R*S*-*-$file.tex"
 file=`cd problems;ls $file`
 # this form of regex is needed because [a-z] set depends on locale
-if [[ ! ( $file =~ ^[JNPES]-R[0123456789]+S[0123456789]-[0123456789]+-[abcdefghijklmnopqrstuvwxyz_]+\.tex$ ) ]]; then
+if [[ ! ( $file =~ ^[JNPES]-R[0-9]+S[0-9]-[0-9]+-[a-z_]+\.tex$ ) ]]; then
     echo "Bad file format:" $file"."
     exit -1 
 fi

--- a/scripts/bin/fks-moveToFykos.sh
+++ b/scripts/bin/fks-moveToFykos.sh
@@ -49,12 +49,13 @@ fi
 file=`sed "s/[JNPES]-\([a-z_]*\)/\1/g" <<< $3`
 file="?-R*S*-*-$file.tex"
 file=`cd problems;ls $file`
-if [[ !($file =~ [a-z_]+) ]]; then
+# this form of regex is needed because [a-z] set depends on locale
+if [[ ! ( $file =~ ^[abcdefghijklmnopqrstuvwxyz_]+$ ) ]]; then
     echo "Bad file format:" $file"."
     exit -1 
 fi
 
-prefix=`sed 's/\([JNPES]-R[0-9]*S[0-9]-[0-9]\+\).*/\1/' <<< $file`
+prefix=`sed 's/\([JNPES]-R[0-9]*S[0-9]-[0-9]\+-\).*/\1/' <<< $file`
 #echo -e $prefix"\n"
 
 
@@ -97,7 +98,7 @@ for f in `git ls-files`; do
     echo -e "\n############ "$f":"
     case $ext in
         "tex"|"plt")
-            sed  -i "s/$prefix/problem$1-$2/g" $f
+            sed  -i "s/$prefix/problem$1-$2-/g" $f
             git diff $f
             git add $f
             ;;
@@ -105,10 +106,10 @@ for f in `git ls-files`; do
             makefileinc=$makefileinc" "$f
             ;;
     esac
-    git mv $f `sed "s/$prefix/problem$1-$2/g" <<< $f`
+    git mv $f `sed "s/$prefix/problem$1-$2-/g" <<< $f`
 done
 echo ""
-makefileinc=`sed "s/$prefix/problem$1-$2/g" <<< $makefileinc`
+makefileinc=`sed "s/$prefix/problem$1-$2-/g" <<< $makefileinc`
 
 cat << EOF
 


### PR DESCRIPTION
There was problem that moving i.e. J-R31-S5-2-dog.tex also matched J-R31-S5-2*.tex, i.e. J-R31-S5-25-fox.tex

Also the regex for checking task name for invalid characters was not working correctly.